### PR TITLE
Documentation for Work Item Delete processor

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -66,4 +66,4 @@ For details on how to add the field in each case, and trouble shooting check the
 
 ## My work items aren't being deleted when using WorkItemDeleteConfig
 
-This tool looks for an Area Path called `_DeleteMe` before applying any extra queries specified in the configuration json file. Ensure the area path exists and that you've moved the work items into it which you want to delete before running.
+This tool looks for an Area Path called `_DeleteMe` before applying any extra queries specified in the configuration json file. Ensure the area path exists and that you've moved the work items into it which you want to delete before running. Further details on creating this can be found on [Server Configuration page](server-configuration.md).

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -36,7 +36,7 @@ You do have to be careful with this process, it does assume that you are not cle
 
 That said it is often a good idea to build up your configuration processor by processor. Proving each one works as required before adding the next one.
 
-## No work items get migrate
+## No work items get migrated
 
 A number of processors have a setting `"PrefixProjectToNodes": false`. If set to true this inserts the name of the source Team Project into the created structure e.g. Area path, Iteration path, or Work Item queries. It is also used by the migration processor. 
 
@@ -63,3 +63,7 @@ How the `ReflectedWorkItemId` field is added depends on whether the system, ther
 - VSTS when the instance has been imported using the  [VSTS Migration Tool](https://blogs.msdn.microsoft.com/visualstudioalm/2016/11/16/import-your-tfs-database-into-visual-studio-team-services/)
 
 For details on how to add the field in each case, and trouble shooting check the [server configuration page](server-configuration.md)
+
+## My work items aren't being deleted when using WorkItemDeleteConfig
+
+This tool looks for an Area Path called `_DeleteMe` before applying any extra queries specified in the configuration json file. Ensure the area path exists and that you've moved the work items into it which you want to delete before running.

--- a/docs/index.md
+++ b/docs/index.md
@@ -41,7 +41,7 @@ There are other processors that can be used to migrate, or process, different so
 #### In-Place Processors
 
 - **WorkItemUpdate** - Need to just update work items in place, use this and only set the Target. All field mappings work...
-- **WorkItemDelete** - Woops... Can I just start again? Feed this a query and watch those items vanish ***WARNING***
+- **WorkItemDelete** - Woops... Can I just start again? Feed this a query and watch those items vanish. ***WARNING*** Work items need to be under an Area Path named `_DeleteMe` to be removed.
 
 #### Migrators
 

--- a/docs/server-configuration.md
+++ b/docs/server-configuration.md
@@ -83,3 +83,7 @@ Once you have created the `ReflectedWorkItemId` field and confirmed you have the
     
 }
 ```
+
+## Work Item Delete Area Path
+
+The WorkItemDeleteConfig processor requires that an Area Path named `_DeleteMe` exists, to create it you must be modifying the project level settings and create it as a child of the project level area path. [More information about area path creation](https://www.visualstudio.com/en-us/docs/work/customize/modify-areas-iterations).


### PR DESCRIPTION
I noticed there was almost no information about using the WorkItemDeleteConfig, particularly how it actually worked with regards to the Area Path it looks under for work items. I've had a few people asking me about it when I was showing them the tool and had to dig into the code to find out about the _DeleteMe requirement. 

I've added a bit of documentation as a starting point which should probably be expanded upon at some point.