### PR TITLE
Issue11: Task work item type ClosedDate is not editable

### DIFF
--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -1,7 +1,7 @@
 assembly-versioning-scheme: MajorMinorPatch
 mode: ContinuousDeployment
 continuous-delivery-fallback-tag: ''
-next-version: 7.0.1
+next-version: 7.0.2
 branches:
   master:
     mode: ContinuousDeployment

--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -1,7 +1,7 @@
 assembly-versioning-scheme: MajorMinorPatch
 mode: ContinuousDeployment
 continuous-delivery-fallback-tag: ''
-next-version: 7.0.2
+next-version: 7.1.0
 branches:
   master:
     mode: ContinuousDeployment

--- a/src/VstsSyncMigrator.Core/Execution/MigrationContext/WorkItemMigrationContext.cs
+++ b/src/VstsSyncMigrator.Core/Execution/MigrationContext/WorkItemMigrationContext.cs
@@ -185,34 +185,25 @@ namespace VstsSyncMigrator.Engine
             WorkItem newwit = destProject.WorkItemTypes[destType].NewWorkItem();
             NewWorkItemTimer.Stop();
             Telemetry.Current.TrackDependency("TeamService", "NewWorkItem", NewWorkItemstartTime, NewWorkItemTimer.Elapsed, true);
-            Trace.WriteLine(string.Format("Dependnacy: {0} - {1} - {2} - {3} - {4}", "TeamService", "NewWorkItem", NewWorkItemstartTime, NewWorkItemTimer.Elapsed, true), "WorkItemMigrationContext");
+            Trace.WriteLine(string.Format("Dependancy: {0} - {1} - {2} - {3} - {4}", "TeamService", "NewWorkItem", NewWorkItemstartTime, NewWorkItemTimer.Elapsed, true), "WorkItemMigrationContext");
             newwit.Title = oldWi.Title;
             newwit.State = oldWi.State;
-            switch (newwit.State)
-            {
-                case "Done":
-                    newwit.Fields["Microsoft.VSTS.Common.ClosedDate"].Value = DateTime.Now;
-                    break;
-                case "Closed":
-                    newwit.Fields["Microsoft.VSTS.Common.ClosedDate"].Value = DateTime.Now;
-                    break;
-                default:
-                    break;
-            }
             newwit.Reason = oldWi.Reason;
             
             foreach (Field f in oldWi.Fields)
             {
-                if (newwit.Fields.Contains(f.ReferenceName) && !_ignore.Contains(f.ReferenceName))
+                if (newwit.Fields.Contains(f.ReferenceName) && !_ignore.Contains(f.ReferenceName) && newwit.Fields[f.ReferenceName].IsEditable)
                 {
                     newwit.Fields[f.ReferenceName].Value = oldWi.Fields[f.ReferenceName].Value;
                 }
             }
+
             if (config.PrefixProjectToNodes)
             {
                 newwit.AreaPath = string.Format(@"{0}\{1}", newwit.Project.Name, oldWi.AreaPath);
                 newwit.IterationPath = string.Format(@"{0}\{1}", newwit.Project.Name, oldWi.IterationPath);
-            } else
+            }
+            else
             {
                 var regex = new Regex(Regex.Escape(oldWi.Project.Name));
                 newwit.AreaPath = regex.Replace(oldWi.AreaPath, newwit.Project.Name, 1);

--- a/src/VstsSyncMigrator.Core/Telemetry.cs
+++ b/src/VstsSyncMigrator.Core/Telemetry.cs
@@ -28,7 +28,7 @@ namespace VstsSyncMigrator.Engine
 
         public static void InitiliseTelemetry()
         {
-            if (EnableTrace) { Trace.Listeners.Add(new ApplicationInsightsTraceListener(applicationInsightsKey)); }
+            // if (EnableTrace) { Trace.Listeners.Add(new ApplicationInsightsTraceListener(applicationInsightsKey)); }
             TelemetryConfiguration.Active.InstrumentationKey = applicationInsightsKey;
             telemetryClient = new TelemetryClient();
             telemetryClient.InstrumentationKey = applicationInsightsKey;


### PR DESCRIPTION
Added IsEditable check for fields being updated. It seems that the Task work item type field ClosedDate is not editable unlike other work item types. For Tasks in a closed state that are migrated, the ClosedDate field is auto populated with the current date and time.