### PR TITLE
Test plans (and all sub-suites of them) to be migrated can be filtered by tags

### DIFF
--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -1,7 +1,7 @@
 assembly-versioning-scheme: MajorMinorPatch
 mode: ContinuousDeployment
 continuous-delivery-fallback-tag: ''
-next-version: 7.1.1
+next-version: 7.1.2
 branches:
   master:
     mode: ContinuousDeployment

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -150,7 +150,8 @@ The global configuration created by the `init` command look like this:
 		}, {
 			"ObjectType": "VstsSyncMigrator.Engine.Configuration.Processing.TestPlansAndSuitsMigrationConfig",
 			"Enabled": false,
-			"PrefixProjectToNodes": true
+			"PrefixProjectToNodes": true,
+			"OnlyElementsWithTag" : "tag"
 		}, {
 			"ObjectType": "VstsSyncMigrator.Engine.Configuration.Processing.TestRunsMigrationConfig",
 			"Enabled": false,

--- a/docs/usage/command-line.md
+++ b/docs/usage/command-line.md
@@ -145,7 +145,8 @@ Note that:
 		}, {
 			"ObjectType": "VstsSyncMigrator.Engine.Configuration.Processing.TestPlansAndSuitsMigrationConfig",
 			"Enabled": false,
-			"PrefixProjectToNodes": true
+			"PrefixProjectToNodes": true,
+			"OnlyElementsWithTag" : "tag"
 		}, {
 			"ObjectType": "VstsSyncMigrator.Engine.Configuration.Processing.TestRunsMigrationConfig",
 			"Enabled": false,

--- a/src/VstsSyncMigrator.Core/Configuration/Processing/TestPlansAndSuitsMigrationConfig.cs
+++ b/src/VstsSyncMigrator.Core/Configuration/Processing/TestPlansAndSuitsMigrationConfig.cs
@@ -7,6 +7,7 @@ namespace VstsSyncMigrator.Engine.Configuration.Processing
     {
         public bool PrefixProjectToNodes { get; set; }
         public bool Enabled { get; set; }
+        public string OnlyElementsWithTag { get; set; }
 
         public Type Processor
         {


### PR DESCRIPTION
See original PR #21.

Separated changes, which are only related to the filtering test plans and suites by tags.