### PR TITLE
Link migration now does also fix shared steps of test cases

### DIFF
--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -1,7 +1,7 @@
 assembly-versioning-scheme: MajorMinorPatch
 mode: ContinuousDeployment
 continuous-delivery-fallback-tag: ''
-next-version: 7.1.1
+next-version: 7.1.4
 branches:
   master:
     mode: ContinuousDeployment


### PR DESCRIPTION
... as they are also appearing as links in TFS.

This is a PR to isolate changes from the old PR #21.