### PR TITLE
Support non-string values and empty regex

### DIFF
--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -1,7 +1,7 @@
 assembly-versioning-scheme: MajorMinorPatch
 mode: ContinuousDeployment
 continuous-delivery-fallback-tag: ''
-next-version: 7.2.0
+next-version: 7.2.1
 branches:
   master:
     mode: ContinuousDeployment

--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -1,7 +1,7 @@
 assembly-versioning-scheme: MajorMinorPatch
 mode: ContinuousDeployment
 continuous-delivery-fallback-tag: ''
-next-version: 7.2.1
+next-version: 7.3.0
 branches:
   master:
     mode: ContinuousDeployment

--- a/src/VstsSyncMigrator.Core/Execution/FieldMaps/FieldValuetoTagMap.cs
+++ b/src/VstsSyncMigrator.Core/Execution/FieldMaps/FieldValuetoTagMap.cs
@@ -37,32 +37,30 @@ namespace VstsSyncMigrator.Engine
 
                 // only proceed if value is available
                 var value = source.Fields[config.sourceField].Value;
-                var apply = false;
+                var match = false;
                 if (value != null)
                 {
                     if (!string.IsNullOrEmpty(config.pattern))
                     {
                         // regular expression matching is being used
-                        if (Regex.IsMatch(value.ToString(), config.pattern))
-                        {
-                            apply = true;
-                        }
+                        match = Regex.IsMatch(value.ToString(), config.pattern);
                     }
                     else
                     {
                         // always apply tag if value exists
-                        apply = true;
+                        match = true;
                     }
+                }
 
-                    // tag will be added
-                    if (apply)
-                    {
-                        var newTag = string.IsNullOrEmpty(config.formatExpression) ? value.ToString() : string.Format(config.formatExpression, value);
-                        if (!string.IsNullOrWhiteSpace(newTag))
-                            tags.Add(newTag);
-                    }
+                // add new tag if available
+                if (match)
+                {
+                    // format or simple to string
+                    var newTag = string.IsNullOrEmpty(config.formatExpression) ? value.ToString() : string.Format(config.formatExpression, value);
+                    if (!string.IsNullOrWhiteSpace(newTag))
+                        tags.Add(newTag);
 
-                    // rewrite tag values if change
+                    // rewrite tag values if changed
                     var newTags = string.Join(";", tags.Distinct());
                     if (newTags != target.Tags)
                     {

--- a/src/VstsSyncMigrator.Core/Execution/FieldMaps/FieldValuetoTagMap.cs
+++ b/src/VstsSyncMigrator.Core/Execution/FieldMaps/FieldValuetoTagMap.cs
@@ -14,7 +14,7 @@ namespace VstsSyncMigrator.Engine
     public class FieldValuetoTagMap : IFieldMap
     {
 
-        FieldValuetoTagMapConfig config;
+        readonly FieldValuetoTagMapConfig config;
 
         public FieldValuetoTagMap(FieldValuetoTagMapConfig config)
         {


### PR DESCRIPTION
Works without a specified regex pattern.
Supports non-string types properly.
Cleans out empty values to prevent some various errors.