### PR TITLE
#53 - FieldMergeMap - Fix null-exception due to `doneMatch` being set to `null`

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -72,7 +72,7 @@ The global configuration created by the `init` command look like this:
 			"sourceField2": "Microsoft.VSTS.Common.AcceptanceCriteria",
 			"targetField": "System.Description",
 			"formatExpression": "{0} <br/><br/><h3>Acceptance Criteria</h3>{1}",
-			"doneMatch": null
+			"doneMatch": "##DONE##"
 		}, {
 			"ObjectType": "VstsSyncMigrator.Engine.Configuration.FieldMap.RegexFieldMapConfig",
 			"WorkItemTypeName": "*",

--- a/docs/usage/command-line.md
+++ b/docs/usage/command-line.md
@@ -67,7 +67,7 @@ Note that:
 			"sourceField2": "Microsoft.VSTS.Common.AcceptanceCriteria",
 			"targetField": "System.Description",
 			"formatExpression": "{0} <br/><br/><h3>Acceptance Criteria</h3>{1}",
-			"doneMatch": null
+			"doneMatch": "##DONE##"
 		}, {
 			"ObjectType": "VstsSyncMigrator.Engine.Configuration.FieldMap.RegexFieldMapConfig",
 			"WorkItemTypeName": "*",

--- a/src/VstsSyncMigrator.Core/Configuration/FieldMap/FieldMergeMapConfig.cs
+++ b/src/VstsSyncMigrator.Core/Configuration/FieldMap/FieldMergeMapConfig.cs
@@ -14,7 +14,7 @@ namespace VstsSyncMigrator.Engine.Configuration.FieldMap
         public string sourceField2 { get; set; }
         public string targetField { get; set; }
         public string formatExpression { get; set; }
-        public string doneMatch { get; set; }
+        public string doneMatch { get; set; } = "##DONE##";
         public Type FieldMap
         {
             get

--- a/src/VstsSyncMigrator.Core/Execution/FieldMaps/FieldMergeMap.cs
+++ b/src/VstsSyncMigrator.Core/Execution/FieldMaps/FieldMergeMap.cs
@@ -17,6 +17,11 @@ namespace VstsSyncMigrator.Engine.ComponentContext
         public FieldMergeMap(FieldMergeMapConfig config)
         {
             this.config = config;
+
+            if(string.IsNullOrWhiteSpace(this.config.doneMatch))
+            {
+                throw new ArgumentNullException($"The {nameof(config.doneMatch)} configuration parameter cannot be null or empty.");
+            }
         }
 
         internal override void InternalExecute(WorkItem source, WorkItem target)
@@ -25,11 +30,11 @@ namespace VstsSyncMigrator.Engine.ComponentContext
             {
                 if (source.Fields[config.sourceField1].Value != null)
                 {
-                    if (target.Fields[config.targetField].Value.ToString().Contains("##DONE##") || target.Fields[config.targetField].Value.ToString().Contains(config.doneMatch))
+                    if (target.Fields[config.targetField].Value.ToString().Contains(config.doneMatch))
                     {
                         Trace.WriteLine(string.Format("  [SKIP] field already merged {0}:{1}+{2} to {3}:{4}", source.Id, config.sourceField1, config.sourceField2, target.Id, config.targetField));
                     } else { 
-                        target.Fields[config.targetField].Value = string.Format(config.formatExpression, source.Fields[config.sourceField1].Value.ToString(), source.Fields[config.sourceField2].Value.ToString()) + "##DONE##";
+                        target.Fields[config.targetField].Value = string.Format(config.formatExpression, source.Fields[config.sourceField1].Value.ToString(), source.Fields[config.sourceField2].Value.ToString()) + config.doneMatch;
                         Trace.WriteLine(string.Format("  [UPDATE] field merged {0}:{1}+{2} to {3}:{4}", source.Id, config.sourceField1, config.sourceField2, target.Id, config.targetField));
                     }
                 }


### PR DESCRIPTION
Converted the  configuration property to be the sole driver of the `FieldMergeMap` rather than using it in addition to a static-set value.  Set the configuration to a default and added null checking.  Updated documentation.