### PR TITLE
Adds history entry for each migrated revision, so that "Discussion" is also migrated

### DIFF
--- a/src/VstsSyncMigrator.Core/Execution/MigrationContext/WorkItemRevisionReplayMigrationContext.cs
+++ b/src/VstsSyncMigrator.Core/Execution/MigrationContext/WorkItemRevisionReplayMigrationContext.cs
@@ -168,6 +168,13 @@ namespace VstsSyncMigrator.Engine
 
                         PopulateWorkItem(currentRevisionWorkItem, newwit, destType);
                         me.ApplyFieldMappings(currentRevisionWorkItem, newwit);
+
+                        newwit.Fields["System.ChangedBy"].Value =
+                            currentRevisionWorkItem.Revisions[revision.Index].Fields["System.ChangedBy"].Value;
+
+                        newwit.Fields["System.History"].Value =
+                            currentRevisionWorkItem.Revisions[revision.Index].Fields["System.History"].Value;
+
                         var fails = newwit.Validate();
 
                         foreach (Field f in fails)
@@ -176,9 +183,6 @@ namespace VstsSyncMigrator.Engine
                                 $"{current} - Invalid: {currentRevisionWorkItem.Id}-{currentRevisionWorkItem.Type.Name}-{f.ReferenceName}",
                                 Name);
                         }
-
-                        newwit.Fields["System.ChangedBy"].Value = 
-                            currentRevisionWorkItem.Revisions[revision.Index].Fields["System.ChangedBy"].Value;
 
                         newwit.Save();
                         Trace.WriteLine(


### PR DESCRIPTION
For Work Item revision replay based migrations, adds the original entry in the "History" field to the migrated revision. This way, any discussions in the History field are migrated to the target system.
