### PR TITLE
Fixes the following issues

### DIFF
--- a/src/VstsSyncMigrator.Core/Execution/ComponentContext/WorkItemStoreContext.cs
+++ b/src/VstsSyncMigrator.Core/Execution/ComponentContext/WorkItemStoreContext.cs
@@ -53,7 +53,8 @@ namespace VstsSyncMigrator.Engine
 
         public string CreateReflectedWorkItemId(WorkItem wi)
         {
-            return string.Format("{0}/{1}/{2}", wi.Store.TeamProjectCollection.Uri, wi.Project.Name, wi.Id);
+            return string.Format("{0}/{1}/_workitems/edit/{2}", wi.Store.TeamProjectCollection.Uri, wi.Project.Name, wi.Id);
+
         }
         public int GetReflectedWorkItemId(WorkItem wi, string reflectedWotkItemIdField)
         {

--- a/src/VstsSyncMigrator.Core/Execution/MigrationContext/TestConfigurationsMigrationContext.cs
+++ b/src/VstsSyncMigrator.Core/Execution/MigrationContext/TestConfigurationsMigrationContext.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.TeamFoundation.TestManagement.Client;
+﻿using System;
+using Microsoft.TeamFoundation.TestManagement.Client;
 using System.Diagnostics;
 using System.Linq;
 using VstsSyncMigrator.Engine.ComponentContext;
@@ -65,7 +66,8 @@ namespace VstsSyncMigrator.Engine
 
         private ITestConfiguration GetCon(ITestConfigurationHelper tch, string configToFind)
         {
-            return (from tv in tch.Query("Select * From TestConfiguration") where tv.Name == configToFind select tv).SingleOrDefault();
+            // Test configurations are case insensitive in VSTS so need ignore case in comparison
+            return tch.Query("Select * From TestConfiguration").FirstOrDefault(variable => string.Equals(variable.Name, configToFind, StringComparison.OrdinalIgnoreCase));
         }
     }
 }

--- a/src/VstsSyncMigrator.Core/Execution/MigrationContext/TestPlansAndSuitsMigrationContext.cs
+++ b/src/VstsSyncMigrator.Core/Execution/MigrationContext/TestPlansAndSuitsMigrationContext.cs
@@ -524,40 +524,30 @@ namespace VstsSyncMigrator.Engine
             FixWorkItemIdInQuery(targetSuitChild);
         }
 
-        private void FixQueryForTeamProjectNameChange(ITestSuiteBase source, IDynamicTestSuite targetSuitChild,
-            TestManagementContext targetTestStore)
+        private void FixQueryForTeamProjectNameChange(ITestSuiteBase source, IDynamicTestSuite targetSuitChild, TestManagementContext targetTestStore)
         {
             // Replacing old projectname in queries with new projectname
             // The target team project name is only available via target test store because the dyn. testsuite isnt saved at this point in time
             if (!source.Plan.Project.TeamProjectName.Equals(targetTestStore.Project.TeamProjectName))
             {
-                Trace.WriteLine(string.Format(
-                    @"Team Project names dont match. We need to fix the query in dynamic test suite {0} - {1}.", source.Id,
-                    source.Title));
-                Trace.WriteLine(string.Format(@"Replacing old project name {1} in query {0} with new team project name {2}",
-                    targetSuitChild.Query.QueryText,
-                    source.Plan.Project.TeamProjectName,
-                    targetTestStore.Project.TeamProjectName
-                ));
-
-                // it is possible that user has used project name in query values. we try only to change iteration + area path values
-                // A child level is selected in area / iteration path
-                targetSuitChild.Query = targetSuitChild.Project.CreateTestQuery(
-                    targetSuitChild.Query.QueryText.Replace(
-                        string.Format(@"'{0}\", source.Plan.Project.TeamProjectName),
-                        string.Format(@"'{0}\", targetTestStore.Project.TeamProjectName)
-                    ));
-
-                // Only root level is selected in area / iteration path
-                targetSuitChild.Query = targetSuitChild.Project.CreateTestQuery(
-                    targetSuitChild.Query.QueryText.Replace(
-                        string.Format(@"'{0}'", source.Plan.Project.TeamProjectName),
-                        string.Format(@"'{0}'", targetTestStore.Project.TeamProjectName)
-                    ));
-
-                ValidateAndFixTestSuiteQuery(source, targetSuitChild, targetTestStore);
-
-                targetSuitChild.Repopulate();
+                Trace.WriteLine(string.Format(@"Team Project names dont match. We need to fix the query in dynamic test suite {0} - {1}.", source.Id, source.Title));
+                Trace.WriteLine(string.Format(@"Replacing old project name {1} in query {0} with new team project name {2}", targetSuitChild.Query.QueryText, source.Plan.Project.TeamProjectName, targetTestStore.Project.TeamProjectName));
+                // First need to check is prefix project nodes has been applied for the migration
+                if (config.PrefixProjectToNodes)
+                {
+                    // if prefix project nodes has been applied we need to take the original area/iteration value and prefix
+                    targetSuitChild.Query =
+                        targetSuitChild.Project.CreateTestQuery(targetSuitChild.Query.QueryText.Replace(
+                            string.Format(@"'{0}", source.Plan.Project.TeamProjectName),
+                            string.Format(@"'{0}\{1}", targetTestStore.Project.TeamProjectName, source.Plan.Project.TeamProjectName)));
+                }
+                else
+                {
+                    // If we are not profixing project nodes then we just need to take the old value for the project and replace it with the new project value
+                    targetSuitChild.Query = targetSuitChild.Project.CreateTestQuery(targetSuitChild.Query.QueryText.Replace(
+                            string.Format(@"'{0}", source.Plan.Project.TeamProjectName),
+                            string.Format(@"'{0}", targetTestStore.Project.TeamProjectName)));
+                }
                 Trace.WriteLine(string.Format("New query is now {0}", targetSuitChild.Query.QueryText));
             }
         }

--- a/src/VstsSyncMigrator.Core/Execution/MigrationContext/TestVeriablesMigrationContext.cs
+++ b/src/VstsSyncMigrator.Core/Execution/MigrationContext/TestVeriablesMigrationContext.cs
@@ -14,15 +14,11 @@ namespace VstsSyncMigrator.Engine
     {
         public override string Name
         {
-            get
-            {
-                return "TestVeriablesMigrationContext";
-            }
+            get { return "TestVeriablesMigrationContext"; }
         }
 
 
         // http://blogs.microsoft.co.il/shair/2015/02/02/tfs-api-part-56-test-configurations/
-
 
         public TestVeriablesMigrationContext(MigrationEngine me, TestVariablesMigrationConfig config) : base(me, config)
         {
@@ -43,7 +39,7 @@ namespace VstsSyncMigrator.Engine
             foreach (var sourceVar in sourceVars)
             {
                 Trace.WriteLine(string.Format("Copy: {0}", sourceVar.Name));
-                ITestVariable targetVar= GetVar(targetTmc.Project.TestVariables, sourceVar.Name);
+                ITestVariable targetVar = GetVar(targetTmc.Project.TestVariables, sourceVar.Name);
                 if (targetVar == null)
                 {
                     Trace.WriteLine(string.Format("    Need to create: {0}", sourceVar.Name));
@@ -65,7 +61,7 @@ namespace VstsSyncMigrator.Engine
                         Trace.WriteLine(string.Format("    Need to create: {0}", sourceVal.Value));
                         targetVal = targetTmc.Project.TestVariables.CreateVariableValue(sourceVal.Value);
                         targetVar.AllowedValues.Add(targetVal);
-                       targetVar.Save();
+                        targetVar.Save();
                     }
                     else
                     {
@@ -79,14 +75,18 @@ namespace VstsSyncMigrator.Engine
 
         internal ITestVariable GetVar(ITestVariableHelper tvh, string variableToFind)
         {
-            return (from tv in tvh.Query() where tv.Name == variableToFind select tv).SingleOrDefault();
+            // Test Variables are case insensitive in VSTS so need ignore case in comparison
+            return tvh.Query()
+                .FirstOrDefault(variable => string.Equals(variable.Name, variableToFind,
+                    StringComparison.OrdinalIgnoreCase));
         }
 
         internal ITestVariableValue GetVal(ITestVariable targetVar, string valueToFind)
         {
-            return (from tv in targetVar.AllowedValues where tv.Value == valueToFind select tv).SingleOrDefault();
+            // Test Variable values are case insensitive in VSTS so need ignore case in comparison
+            return targetVar.AllowedValues.FirstOrDefault(
+                variable => string.Equals(variable.Value, valueToFind, StringComparison.OrdinalIgnoreCase));
         }
 
     }
-
-    }
+}


### PR DESCRIPTION
- The reflected work item ID that is generated is not a valid URL
- The searches for test variables, variable values and configurations need to be case insensitive as they are in VSTS
- Fixes an issues where the query used for dynamic wasn't being updated correctly if you used the prefix project nodes attribute