### PR TITLE
Fixing a couple of issues when migrating from VSTS to VSTS

### DIFF
--- a/src/VstsSyncMigrator.Core/Configuration/EngineConfiguration.cs
+++ b/src/VstsSyncMigrator.Core/Configuration/EngineConfiguration.cs
@@ -15,6 +15,7 @@ namespace VstsSyncMigrator.Engine.Configuration
         public TeamProjectConfig Source { get; set; }
         public TeamProjectConfig Target { get; set; }
         public string ReflectedWorkItemIDFieldName { get; set; }
+        public string SourceReflectedWorkItemIDFieldName { get; set; }
         public List<IFieldMapConfig> FieldMaps { get; set; }
         public Dictionary<string, string> WorkItemTypeDefinition { get; set; }
         public List<ITfsProcessingConfig> Processors { get; set; }
@@ -26,6 +27,7 @@ namespace VstsSyncMigrator.Engine.Configuration
             ec.Source = new TeamProjectConfig() { Name = "DemoProjs", Collection = new Uri("https://sdd2016.visualstudio.com/") };
             ec.Target = new TeamProjectConfig() { Name = "DemoProjt", Collection = new Uri("https://sdd2016.visualstudio.com/") };
             ec.ReflectedWorkItemIDFieldName = "TfsMigrationTool.ReflectedWorkItemId";
+            ec.SourceReflectedWorkItemIDFieldName = "ProcessName.ReflectedWorkItemId";
             ec.FieldMaps = new List<IFieldMapConfig>();
             ec.FieldMaps.Add(new MultiValueConditionalMapConfig()
             {

--- a/src/VstsSyncMigrator.Core/Execution/ComponentContext/WorkItemStoreContext.cs
+++ b/src/VstsSyncMigrator.Core/Execution/ComponentContext/WorkItemStoreContext.cs
@@ -53,7 +53,7 @@ namespace VstsSyncMigrator.Engine
 
         public string CreateReflectedWorkItemId(WorkItem wi)
         {
-            return string.Format("{0}/{1}/_workitems/edit/{2}", wi.Store.TeamProjectCollection.Uri, wi.Project.Name, wi.Id);
+            return string.Format("{0}/{1}/_workitems/edit/{2}", wi.Store.TeamProjectCollection.Uri.ToString().TrimEnd('/'), wi.Project.Name, wi.Id);
 
         }
         public int GetReflectedWorkItemId(WorkItem wi, string reflectedWotkItemIdField)

--- a/src/VstsSyncMigrator.Core/Execution/MigrationContext/AttachementImportMigrationContext.cs
+++ b/src/VstsSyncMigrator.Core/Execution/MigrationContext/AttachementImportMigrationContext.cs
@@ -49,7 +49,8 @@ namespace VstsSyncMigrator.Engine
 
                     string reflectedID = fileNameParts[0].Replace('+', ':').Replace("--", "/");
                     string targetFileName = fileNameParts[1];
-                    File.Move(file, Path.Combine(Path.GetDirectoryName(file), targetFileName));
+                    var renamedFilePath = Path.Combine(Path.GetDirectoryName(file), targetFileName);
+                    File.Move(file, renamedFilePath);
                     targetWI = targetStore.FindReflectedWorkItemByReflectedWorkItemId(reflectedID, me.ReflectedWorkItemIdFieldName);
                     if (targetWI != null)
                     {
@@ -58,7 +59,7 @@ namespace VstsSyncMigrator.Engine
                         var attachment = attachments.Where(a => a.Name == targetFileName).FirstOrDefault();
                         if (attachment == null)
                         {
-                            Attachment a = new Attachment(file);
+                            Attachment a = new Attachment(renamedFilePath);
                             targetWI.Attachments.Add(a);
                             targetWI.Save();
                         }
@@ -73,7 +74,7 @@ namespace VstsSyncMigrator.Engine
                         Trace.WriteLine(string.Format("{0} of {1} - Skipping {2} to {3}", current, files.Count, fileName, 0));
                         skipped++;
                     }
-                    System.IO.File.Delete(file);
+                    System.IO.File.Delete(renamedFilePath);
                 } catch (FileAttachmentException ex)
                 {
                     // Probably due to attachment being over size limit

--- a/src/VstsSyncMigrator.Core/Execution/MigrationContext/AttachementImportMigrationContext.cs
+++ b/src/VstsSyncMigrator.Core/Execution/MigrationContext/AttachementImportMigrationContext.cs
@@ -43,13 +43,19 @@ namespace VstsSyncMigrator.Engine
                 string fileName = System.IO.Path.GetFileName(file);
                 try
                 {
-                    string reflectedID = fileName.Split('#')[0].Replace('+', ':').Replace("--", "/");
+                    var fileNameParts = fileName.Split('#');
+                    if (fileNameParts.Length != 2)
+                        continue;
+
+                    string reflectedID = fileNameParts[0].Replace('+', ':').Replace("--", "/");
+                    string targetFileName = fileNameParts[1];
+                    File.Move(file, Path.Combine(Path.GetDirectoryName(file), targetFileName));
                     targetWI = targetStore.FindReflectedWorkItemByReflectedWorkItemId(reflectedID, me.ReflectedWorkItemIdFieldName);
                     if (targetWI != null)
                     {
                         Trace.WriteLine(string.Format("{0} of {1} - Import {2} to {3}", current, files.Count, fileName, targetWI.Id));
                         var attachments = targetWI.Attachments.Cast<Attachment>();
-                        var attachment = attachments.Where(a => a.Name == fileName).FirstOrDefault();
+                        var attachment = attachments.Where(a => a.Name == targetFileName).FirstOrDefault();
                         if (attachment == null)
                         {
                             Attachment a = new Attachment(file);

--- a/src/VstsSyncMigrator.Core/Execution/MigrationContext/HtmlFieldEmbeddedImageMigrationContext.cs
+++ b/src/VstsSyncMigrator.Core/Execution/MigrationContext/HtmlFieldEmbeddedImageMigrationContext.cs
@@ -135,7 +135,7 @@ namespace VstsSyncMigrator.Engine
                                 string newImageLink =
                                     String.Format(
                                         "{0}/WorkItemTracking/v1.0/AttachFileHandler.ashx?FileNameGuid={1}&amp;FileName={2}",
-                                        newTfsurl, attachmentGuid, newFileNameMatch.Value);
+                                        newTfsurl.TrimEnd('/'), attachmentGuid, newFileNameMatch.Value);
 
                                 field.Value = field.Value.ToString().Replace(match.Value, newImageLink);
                                 wi.Attachments.RemoveAt(attachmentIndex);

--- a/src/VstsSyncMigrator.Core/Execution/MigrationContext/LinkMigrationContext.cs
+++ b/src/VstsSyncMigrator.Core/Execution/MigrationContext/LinkMigrationContext.cs
@@ -279,7 +279,7 @@ namespace VstsSyncMigrator.Engine
             WorkItem wiTargetR;
             if (!(wiTargetL == null)
                 && wiSourceR.Project.Name == wiTargetL.Project.Name
-                && wiSourceR.Project.Store.TeamProjectCollection.Uri.ToString() == wiTargetL.Project.Store.TeamProjectCollection.Uri.ToString())
+                && wiSourceR.Project.Store.TeamProjectCollection.Uri.ToString().Replace("/", "") == wiTargetL.Project.Store.TeamProjectCollection.Uri.ToString().Replace("/", ""))
             {
                 // Moving to same team project as SourceR
                 wiTargetR = wiSourceR;
@@ -291,7 +291,7 @@ namespace VstsSyncMigrator.Engine
                 if (wiTargetR == null) // Assume source only (other team projkect)
                 {
                     wiTargetR = wiSourceR;
-                    if (wiTargetR.Project.Store.TeamProjectCollection.Uri != wiSourceR.Project.Store.TeamProjectCollection.Uri)
+                    if (wiTargetR.Project.Store.TeamProjectCollection.Uri.ToString().Replace("/", "") != wiSourceR.Project.Store.TeamProjectCollection.Uri.ToString().Replace("/", ""))
                     {
                         wiTargetR = null; // Totally bogus break! as not same team collection
                     }

--- a/src/VstsSyncMigrator.Core/Execution/MigrationContext/WorkItemMigrationContext.cs
+++ b/src/VstsSyncMigrator.Core/Execution/MigrationContext/WorkItemMigrationContext.cs
@@ -125,9 +125,9 @@ namespace VstsSyncMigrator.Engine
                             newwit.Save();
                             newwit.Close();
                             Trace.WriteLine(string.Format("...Saved as {0}", newwit.Id), this.Name);
-                            if (sourceWI.Fields.Contains(me.ReflectedWorkItemIdFieldName) && _config.UpdateSoureReflectedId)
+                            if (sourceWI.Fields.Contains(me.SourceReflectedWorkItemIdFieldName) && _config.UpdateSoureReflectedId)
                             {
-                                sourceWI.Fields[me.ReflectedWorkItemIdFieldName].Value = targetStore.CreateReflectedWorkItemId(newwit);
+                                sourceWI.Fields[me.SourceReflectedWorkItemIdFieldName].Value = targetStore.CreateReflectedWorkItemId(newwit);
                             }
                             sourceWI.Save();
                             Trace.WriteLine(string.Format("...and Source Updated {0}", sourceWI.Id), this.Name);

--- a/src/VstsSyncMigrator.Core/Execution/MigrationContext/WorkItemRevisionReplayMigrationContext.cs
+++ b/src/VstsSyncMigrator.Core/Execution/MigrationContext/WorkItemRevisionReplayMigrationContext.cs
@@ -213,10 +213,9 @@ namespace VstsSyncMigrator.Engine
                     newwit.Close();
                     Trace.WriteLine($"...Saved as {newwit.Id}", Name);
 
-                    if (sourceWorkItem.Fields.Contains(me.ReflectedWorkItemIdFieldName) &&
-                        _config.UpdateSoureReflectedId)
+                    if (_config.UpdateSoureReflectedId && sourceWorkItem.Fields.Contains(me.SourceReflectedWorkItemIdFieldName))
                     {
-                        sourceWorkItem.Fields[me.ReflectedWorkItemIdFieldName].Value =
+                        sourceWorkItem.Fields[me.SourceReflectedWorkItemIdFieldName].Value =
                             targetStore.CreateReflectedWorkItemId(newwit);
                         sourceWorkItem.Save();
                         Trace.WriteLine($"...and Source Updated {sourceWorkItem.Id}", Name);

--- a/src/VstsSyncMigrator.Core/MigrationEngine.cs
+++ b/src/VstsSyncMigrator.Core/MigrationEngine.cs
@@ -22,7 +22,8 @@ namespace VstsSyncMigrator.Engine
         ITeamProjectContext source;
         ITeamProjectContext target;
         string reflectedWorkItemIdFieldName = "TfsMigrationTool.ReflectedWorkItemId";
-        
+        private string sourceReflectedWorkItemIdFieldName = "ProcessName.ReflectedWorkItemId";
+
         public MigrationEngine()
         {
 
@@ -44,6 +45,7 @@ namespace VstsSyncMigrator.Engine
                 this.SetTarget(new TeamProjectContext(config.Target.Collection, config.Target.Name));
             }           
             this.SetReflectedWorkItemIdFieldName(config.ReflectedWorkItemIDFieldName);
+            this.SetSourceReflectedWorkItemIdFieldName(config.SourceReflectedWorkItemIDFieldName);
             if (config.FieldMaps != null)
             {
                 foreach (IFieldMapConfig fieldmapConfig in config.FieldMaps)
@@ -105,6 +107,12 @@ namespace VstsSyncMigrator.Engine
             get { return reflectedWorkItemIdFieldName;}
         }
 
+        public string SourceReflectedWorkItemIdFieldName
+        {
+            get { return sourceReflectedWorkItemIdFieldName; }
+        }
+
+
         public ProcessingStatus Run()
         {
             Telemetry.Current.TrackEvent("EngineStart",
@@ -161,6 +169,12 @@ namespace VstsSyncMigrator.Engine
         {
             reflectedWorkItemIdFieldName = fieldName;
         }
+
+        public void SetSourceReflectedWorkItemIdFieldName(string fieldName)
+        {
+            sourceReflectedWorkItemIdFieldName = fieldName;
+        }
+
 
         public void SetSource(ITeamProjectContext teamProjectContext)
         {


### PR DESCRIPTION
Things addressed in this pull request:
* Added support for a source reflected work item id. The field name and/or process name might be different from source and destination. So this will support for specifying both. For example source might be "SourceProcess/ReflectedWorkItemId" while destination be "DstProcess/ReflectedWorkItemId"
* Fixed file names in target work item attachments. It used to migrate as source VSTS/TFS URL + file-name separated by hash, and certain characters replaced. It's now the same file name as the one in the source work item.
* Removed excessive slashes in the reflective work item URLs so that the URLs stays valid.
