### PR TITLE
Case insensitive project name wistore reference

### DIFF
--- a/src/VstsSyncMigrator.Core/Execution/ComponentContext/WorkItemStoreContext.cs
+++ b/src/VstsSyncMigrator.Core/Execution/ComponentContext/WorkItemStoreContext.cs
@@ -48,7 +48,7 @@ namespace VstsSyncMigrator.Engine
 
         public Project GetProject()
         {
-            return (from Project x in wistore.Projects where x.Name == targetTfs.Name select x).SingleOrDefault();
+            return (from Project x in wistore.Projects where x.Name.ToUpper() == targetTfs.Name.ToUpper() select x).SingleOrDefault();
         }
 
         public string CreateReflectedWorkItemId(WorkItem wi)


### PR DESCRIPTION
This may apply to other scenarios, but I was migrating Test Plans and Suites and was receiving a null exception error because I spelled my Team Project as "myteamproject" instead of "MyTeamProject".