### PR TITLE
Make FieldValueMap work for non-string source values

### DIFF
--- a/src/VstsSyncMigrator.Core/Execution/FieldMaps/FieldValueMap.cs
+++ b/src/VstsSyncMigrator.Core/Execution/FieldMaps/FieldValueMap.cs
@@ -23,11 +23,13 @@ namespace VstsSyncMigrator.Engine.ComponentContext
         {
                 if (source.Fields.Contains(config.sourceField))
                 {
-                    // to tag
-                    string value = (string)source.Fields[config.sourceField].Value;
-                    if (config.valueMapping.ContainsKey(value))
+                    string sourceValue = source.Fields[config.sourceField].Value != null 
+                        ? source.Fields[config.sourceField].Value.ToString()
+                        : null;
+
+                    if (sourceValue != null && config.valueMapping.ContainsKey(sourceValue))
                     {
-                        target.Fields[config.targetField].Value = config.valueMapping[value];
+                        target.Fields[config.targetField].Value = config.valueMapping[sourceValue];
                         Trace.WriteLine(string.Format("  [UPDATE] field value mapped {0}:{1} to {2}:{3}", source.Id, config.sourceField, target.Id, config.targetField));
                     }
                 }

--- a/src/VstsSyncMigrator.Core/Execution/MigrationContext/WorkItemRevisionReplayMigrationContext.cs
+++ b/src/VstsSyncMigrator.Core/Execution/MigrationContext/WorkItemRevisionReplayMigrationContext.cs
@@ -168,6 +168,13 @@ namespace VstsSyncMigrator.Engine
 
                         PopulateWorkItem(currentRevisionWorkItem, newwit, destType);
                         me.ApplyFieldMappings(currentRevisionWorkItem, newwit);
+
+                        newwit.Fields["System.ChangedBy"].Value =
+                            currentRevisionWorkItem.Revisions[revision.Index].Fields["System.ChangedBy"].Value;
+
+                        newwit.Fields["System.History"].Value =
+                            currentRevisionWorkItem.Revisions[revision.Index].Fields["System.History"].Value;
+
                         var fails = newwit.Validate();
 
                         foreach (Field f in fails)
@@ -176,9 +183,6 @@ namespace VstsSyncMigrator.Engine
                                 $"{current} - Invalid: {currentRevisionWorkItem.Id}-{currentRevisionWorkItem.Type.Name}-{f.ReferenceName}",
                                 Name);
                         }
-
-                        newwit.Fields["System.ChangedBy"].Value = 
-                            currentRevisionWorkItem.Revisions[revision.Index].Fields["System.ChangedBy"].Value;
 
                         newwit.Save();
                         Trace.WriteLine(


### PR DESCRIPTION
Avoids "cannot convert Int32 to string" exception on integer source fields.