### PR TITLE
Allow default value for FieldValueMapConfig

### DIFF
--- a/src/VstsSyncMigrator.Core/Configuration/EngineConfiguration.cs
+++ b/src/VstsSyncMigrator.Core/Configuration/EngineConfiguration.cs
@@ -53,6 +53,7 @@ namespace VstsSyncMigrator.Engine.Configuration
                 WorkItemTypeName = "*",
                 sourceField = "System.State",
                 targetField = "System.State",
+                defaultValue = "New",
                 valueMapping = new Dictionary<string, string> {
                     { "Approved", "New" },
                     { "New", "New" },

--- a/src/VstsSyncMigrator.Core/Configuration/FieldMap/FieldValueMapConfig.cs
+++ b/src/VstsSyncMigrator.Core/Configuration/FieldMap/FieldValueMapConfig.cs
@@ -12,6 +12,7 @@ namespace VstsSyncMigrator.Engine.Configuration.FieldMap
         public string WorkItemTypeName { get; set; }
         public string sourceField { get; set; }
         public string targetField { get; set; }
+        public string defaultValue { get; set; }
         public Dictionary<string, string> valueMapping { get; set; }
 
 

--- a/src/VstsSyncMigrator.Core/Execution/FieldMaps/FieldValueMap.cs
+++ b/src/VstsSyncMigrator.Core/Execution/FieldMaps/FieldValueMap.cs
@@ -21,18 +21,23 @@ namespace VstsSyncMigrator.Engine.ComponentContext
 
         internal override void InternalExecute(WorkItem source, WorkItem target)
         {
-                if (source.Fields.Contains(config.sourceField))
-                {
-                    string sourceValue = source.Fields[config.sourceField].Value != null 
-                        ? source.Fields[config.sourceField].Value.ToString()
-                        : null;
+            if (source.Fields.Contains(config.sourceField))
+            {
+                string sourceValue = source.Fields[config.sourceField].Value != null 
+                    ? source.Fields[config.sourceField].Value.ToString()
+                    : null;
 
-                    if (sourceValue != null && config.valueMapping.ContainsKey(sourceValue))
-                    {
-                        target.Fields[config.targetField].Value = config.valueMapping[sourceValue];
-                        Trace.WriteLine(string.Format("  [UPDATE] field value mapped {0}:{1} to {2}:{3}", source.Id, config.sourceField, target.Id, config.targetField));
-                    }
+                if (sourceValue != null && config.valueMapping.ContainsKey(sourceValue))
+                {
+                    target.Fields[config.targetField].Value = config.valueMapping[sourceValue];
+                    Trace.WriteLine($"  [UPDATE] field value mapped {source.Id}:{config.sourceField} to {target.Id}:{config.targetField}");
                 }
+                else if (sourceValue != null && !string.IsNullOrEmpty(config.defaultValue))
+                {
+                    target.Fields[config.targetField].Value = config.defaultValue;
+                    Trace.WriteLine($"  [UPDATE] field set to default value {source.Id}:{config.sourceField} to {target.Id}:{config.targetField}");
+                }
+            }
 
         }
     }


### PR DESCRIPTION
Allow default value for FieldValueMapConfig. This eliminates the need to specify each and every source & target value. This can especially handy when dealing with large lists (e.g. area / iteration paths).