### PR TITLE
#143 Reversed caching logic to validate nodes on revision migration.

### DIFF
--- a/src/VstsSyncMigrator.Core/Execution/MigrationContext/WorkItemRevisionReplayMigrationContext.cs
+++ b/src/VstsSyncMigrator.Core/Execution/MigrationContext/WorkItemRevisionReplayMigrationContext.cs
@@ -336,7 +336,7 @@ namespace VstsSyncMigrator.Engine
 
         public bool NodeExists(string nodePath)
         {
-            if (_foundNodes.Contains(nodePath))
+            if (!_foundNodes.Contains(nodePath))
             {
                 NodeInfo node = null;
                 try


### PR DESCRIPTION
Reversed node caching logic to make sure a node is validated if it has not been checked prior.