### PR TITLE
Changes to eliminate redundant comments in migrated items

### DIFF
--- a/src/VstsSyncMigrator.Core/Configuration/Processing/WorkItemMigrationConfig.cs
+++ b/src/VstsSyncMigrator.Core/Configuration/Processing/WorkItemMigrationConfig.cs
@@ -11,11 +11,14 @@ namespace VstsSyncMigrator.Engine.Configuration.Processing
         public bool UpdateCreatedDate { get; set; }
         public bool UpdateCreatedBy { get; set; }
         public bool UpdateSoureReflectedId { get; set; }
+        public bool BuildFieldTable { get; set; }
+        public bool AppendMigrationToolSignatureFooter { get; set; }
 
         public string QueryBit { get; set; }
         public bool Enabled { get; set; }
 
         public Type Processor => typeof(WorkItemMigrationContext);
+
 
         /// <inheritdoc />
         public bool IsProcessorCompatible(IReadOnlyList<ITfsProcessingConfig> otherProcessors)

--- a/src/VstsSyncMigrator.Core/Execution/MigrationContext/WorkItemMigrationContext.cs
+++ b/src/VstsSyncMigrator.Core/Execution/MigrationContext/WorkItemMigrationContext.cs
@@ -296,18 +296,21 @@ namespace VstsSyncMigrator.Engine
 
         private static void BuildCommentTable(WorkItem oldWi, StringBuilder history)
         {
-            history.Append("<p>Comments from previous work item:</p>");
-            history.Append("<table border='1' style='width:100%;border-color:#C0C0C0;'>");
-            foreach (Revision r in oldWi.Revisions)
+            if (oldWi.Revisions != null && oldWi.Revisions.Count > 0)
             {
-                if ((string)r.Fields["System.History"].Value != "" && (string)r.Fields["System.ChangedBy"].Value != "Martin Hinshelwood (Adm)")
+                history.Append("<p>Comments from previous work item:</p>");
+                history.Append("<table border='1' style='width:100%;border-color:#C0C0C0;'>");
+                foreach (Revision r in oldWi.Revisions)
                 {
-                    r.WorkItem.Open();
-                    history.AppendFormat("<tr><td style='align:right;width:100%'><p><b>{0} on {1}:</b></p><p>{2}</p></td></tr>", r.Fields["System.ChangedBy"].Value, DateTime.Parse(r.Fields["System.ChangedDate"].Value.ToString()).ToLongDateString(), r.Fields["System.History"].Value);
+                    if ((string)r.Fields["System.History"].Value != "" && (string)r.Fields["System.ChangedBy"].Value != "Martin Hinshelwood (Adm)")
+                    {
+                        r.WorkItem.Open();
+                        history.AppendFormat("<tr><td style='align:right;width:100%'><p><b>{0} on {1}:</b></p><p>{2}</p></td></tr>", r.Fields["System.ChangedBy"].Value, DateTime.Parse(r.Fields["System.ChangedDate"].Value.ToString()).ToLongDateString(), r.Fields["System.History"].Value);
+                    }
                 }
+                history.Append("</table>");
+                history.Append("<p>&nbsp;</p>");
             }
-            history.Append("</table>");
-            history.Append("<p>&nbsp;</p>");
         }
 
         static bool isNumeric(string val, NumberStyles NumberStyle)

--- a/src/VstsSyncMigrator.Core/Execution/MigrationContext/WorkItemMigrationContext.cs
+++ b/src/VstsSyncMigrator.Core/Execution/MigrationContext/WorkItemMigrationContext.cs
@@ -235,9 +235,9 @@ namespace VstsSyncMigrator.Engine
                 && newwit.Fields["Microsoft.VSTS.Common.BacklogPriority"].Value != null
                 && !isNumeric(newwit.Fields["Microsoft.VSTS.Common.BacklogPriority"].Value.ToString(),
                 NumberStyles.Any))
-                {
-                    newwit.Fields["Microsoft.VSTS.Common.BacklogPriority"].Value = 10;
-                }
+            {
+                newwit.Fields["Microsoft.VSTS.Common.BacklogPriority"].Value = 10;
+            }
 
             StringBuilder description = new StringBuilder();
             description.Append(oldWi.Description);
@@ -245,8 +245,17 @@ namespace VstsSyncMigrator.Engine
 
             StringBuilder history = new StringBuilder();
             BuildCommentTable(oldWi, history);
-            BuildFieldTable(oldWi, history);
-            history.Append("<p>Migrated by <a href='https://nkdagility.visualstudio.com/vsts-sync-migration/'>VSTS/TFS Sync Migration Tool</a> open source.</p>");
+
+            if (_config.BuildFieldTable)
+            {
+                BuildFieldTable(oldWi, history);
+            }
+
+            if (_config.AppendMigrationToolSignatureFooter)
+            {
+                AppendMigratedByFooter(history);
+            }
+
             newwit.History = history.ToString();
 
             fieldMappingTimer.Stop();
@@ -262,6 +271,11 @@ namespace VstsSyncMigrator.Engine
         }
 
 
+        private static void AppendMigratedByFooter(StringBuilder history)
+        {
+            history.Append("<p>Migrated by <a href='https://nkdagility.visualstudio.com/vsts-sync-migration/'>VSTS/TFS Sync Migration Tool</a> open source.</p>");
+        }
+
         private static void BuildFieldTable(WorkItem oldWi, StringBuilder history, bool useHTML = false)
         {
             history.Append("<p>Fields from previous Work Item:</p>");
@@ -273,7 +287,7 @@ namespace VstsSyncMigrator.Engine
                 }
                 else
                 {
-                        history.AppendLine(string.Format("{0}: {1}<br />", f.Name, f.Value.ToString()));
+                    history.AppendLine(string.Format("{0}: {1}<br />", f.Name, f.Value.ToString()));
                 }
 
             }


### PR DESCRIPTION
The first commit was tested by me via migration our VSTS instance.
Unfortunately, I don't have a chance to test the second one - do not writing the comments table title when there is no comments.

![image](https://user-images.githubusercontent.com/5691429/43514820-ae51e174-9589-11e8-8c58-56256fc2017b.png)

