### PR TITLE
Small improvements

### DIFF
--- a/src/VstsSyncMigrator.Console/Program.cs
+++ b/src/VstsSyncMigrator.Console/Program.cs
@@ -55,7 +55,7 @@ namespace VstsSyncMigrator.ConsoleApp
             string logsPath = CreateLogsPath();
             //////////////////////////////////////////////////
             Trace.Listeners.Add(new TextWriterTraceListener(Console.Out));
-            Trace.Listeners.Add(new TextWriterTraceListener(Path.Combine(logsPath, $"{Path.GetFileNameWithoutExtension(args[2])}.log"), "myListener"));
+            Trace.Listeners.Add(new TextWriterTraceListener(Path.Combine(logsPath, "VstsSyncMigrator.log"), "myListener"));
             //////////////////////////////////////////////////
             Trace.WriteLine(System.Reflection.Assembly.GetExecutingAssembly().GetName().Name, "[Info]");
             Version thisVersion = System.Reflection.Assembly.GetExecutingAssembly().GetName().Version;

--- a/src/VstsSyncMigrator.Console/Program.cs
+++ b/src/VstsSyncMigrator.Console/Program.cs
@@ -55,7 +55,7 @@ namespace VstsSyncMigrator.ConsoleApp
             string logsPath = CreateLogsPath();
             //////////////////////////////////////////////////
             Trace.Listeners.Add(new TextWriterTraceListener(Console.Out));
-            Trace.Listeners.Add(new TextWriterTraceListener(Path.Combine(logsPath, "VstsSyncMigrator.log"), "myListener"));
+            Trace.Listeners.Add(new TextWriterTraceListener(Path.Combine(logsPath, $"{Path.GetFileNameWithoutExtension(args[2])}.log"), "myListener"));
             //////////////////////////////////////////////////
             Trace.WriteLine(System.Reflection.Assembly.GetExecutingAssembly().GetName().Name, "[Info]");
             Version thisVersion = System.Reflection.Assembly.GetExecutingAssembly().GetName().Version;
@@ -86,7 +86,7 @@ namespace VstsSyncMigrator.ConsoleApp
             Trace.WriteLine(string.Format("Telemitery Enabled: {0}", Telemetry.Current.IsEnabled().ToString()), "[Info]");
             Trace.WriteLine(string.Format("SessionID: {0}", Telemetry.Current.Context.Session.Id), "[Info]");
             Trace.WriteLine(string.Format("User: {0}", Telemetry.Current.Context.User.Id), "[Info]");
-            Trace.WriteLine(string.Format("Start Time: {0}", startTime.ToUniversalTime()), "[Info]");
+            Trace.WriteLine(string.Format("Start Time: {0}", startTime.ToUniversalTime().ToLocalTime()), "[Info]");
             Trace.WriteLine("------------------------------START-----------------------------", "[Info]");
             //////////////////////////////////////////////////
             int result = (int)Parser.Default.ParseArguments<InitOptions, RunOptions, ExportADGroupsOptions>(args).MapResult(
@@ -108,7 +108,7 @@ namespace VstsSyncMigrator.ConsoleApp
                 System.Threading.Thread.Sleep(1000);
             }
             Trace.WriteLine(string.Format("Duration: {0}", mainTimer.Elapsed.ToString("c")), "[Info]");
-            Trace.WriteLine(string.Format("End Time: {0}", startTime.ToUniversalTime()), "[Info]");
+            Trace.WriteLine(string.Format("End Time: {0}", DateTime.Now), "[Info]");
 #if DEBUG
             Console.ReadKey();
 #endif

--- a/src/VstsSyncMigrator.Core/Configuration/EngineConfiguration.cs
+++ b/src/VstsSyncMigrator.Core/Configuration/EngineConfiguration.cs
@@ -125,7 +125,7 @@ namespace VstsSyncMigrator.Engine.Configuration
             //ec.Processors.Add(new TestRunsMigrationConfig() { Enabled = false });
             ec.Processors.Add(new ImportProfilePictureConfig() { Enabled = false });
             ec.Processors.Add(new ExportProfilePictureFromADConfig() { Enabled = false });
-            ec.Processors.Add(new FixGitCommitLinksConfig() { Enabled = false, TargetRepository = ec.Target.Name });
+            ec.Processors.Add(new FixGitCommitLinksConfig() { Enabled = false, TargetRepository = ec.Target.Name, QueryBit = @"AND [System.ExternalLinkCount] > 0" });
             return ec;
         }
 

--- a/src/VstsSyncMigrator.Core/Execution/ComponentContext/WorkItemStoreContext.cs
+++ b/src/VstsSyncMigrator.Core/Execution/ComponentContext/WorkItemStoreContext.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Linq;
 using Microsoft.TeamFoundation.WorkItemTracking.Client;
 using System.Collections.Generic;

--- a/src/VstsSyncMigrator.Core/Execution/ComponentContext/WorkItemStoreContext.cs
+++ b/src/VstsSyncMigrator.Core/Execution/ComponentContext/WorkItemStoreContext.cs
@@ -60,11 +60,7 @@ namespace VstsSyncMigrator.Engine
         public int GetReflectedWorkItemId(WorkItem wi, string reflectedWotkItemIdField)
         {
             string rwiid = wi.Fields[reflectedWotkItemIdField].Value.ToString();
-            if (Regex.IsMatch(rwiid, @"(http(s)?://)?([\w-]+\.)+[\w-]+(/[\w- ;,./?%&=]*)?"))
-            {
-                return int.Parse(rwiid.Substring(rwiid.LastIndexOf(@"/") + 1));
-            }
-            return 0;
+            return int.Parse(rwiid.Substring(rwiid.LastIndexOf(@"/") + 1));
         }
 
         public WorkItem FindReflectedWorkItem(WorkItem workItemToFind, string reflectedWotkItemIdField, bool cache)
@@ -86,11 +82,7 @@ namespace VstsSyncMigrator.Engine
                 else
                 {
                     found = Store.GetWorkItem(idToFind);
-                    if (!(found.Fields[reflectedWotkItemIdField].Value.ToString() == rwiid))
-                    {
-                        found = null;
-                    }
-                }                
+                }
             }
             if (found == null) { found = FindReflectedWorkItemByReflectedWorkItemId(ReflectedWorkItemId, reflectedWotkItemIdField); }
             if (!workItemToFind.Fields.Contains(reflectedWotkItemIdField))

--- a/src/VstsSyncMigrator.Core/Execution/ComponentContext/WorkItemStoreContext.cs
+++ b/src/VstsSyncMigrator.Core/Execution/ComponentContext/WorkItemStoreContext.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Linq;
 using Microsoft.TeamFoundation.WorkItemTracking.Client;
 using System.Collections.Generic;

--- a/src/VstsSyncMigrator.Core/Execution/ComponentContext/WorkItemStoreContext.cs
+++ b/src/VstsSyncMigrator.Core/Execution/ComponentContext/WorkItemStoreContext.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Linq;
 using Microsoft.TeamFoundation.WorkItemTracking.Client;
 using System.Collections.Generic;
@@ -60,7 +60,11 @@ namespace VstsSyncMigrator.Engine
         public int GetReflectedWorkItemId(WorkItem wi, string reflectedWotkItemIdField)
         {
             string rwiid = wi.Fields[reflectedWotkItemIdField].Value.ToString();
-            return int.Parse(rwiid.Substring(rwiid.LastIndexOf(@"/") + 1));
+            if (Regex.IsMatch(rwiid, @"(http(s)?://)?([\w-]+\.)+[\w-]+(/[\w- ;,./?%&=]*)?"))
+            {
+                return int.Parse(rwiid.Substring(rwiid.LastIndexOf(@"/") + 1));
+            }
+            return 0;
         }
 
         public WorkItem FindReflectedWorkItem(WorkItem workItemToFind, string reflectedWotkItemIdField, bool cache)
@@ -82,7 +86,11 @@ namespace VstsSyncMigrator.Engine
                 else
                 {
                     found = Store.GetWorkItem(idToFind);
-                }
+                    if (!(found.Fields[reflectedWotkItemIdField].Value.ToString() == rwiid))
+                    {
+                        found = null;
+                    }
+                }                
             }
             if (found == null) { found = FindReflectedWorkItemByReflectedWorkItemId(ReflectedWorkItemId, reflectedWotkItemIdField); }
             if (!workItemToFind.Fields.Contains(reflectedWotkItemIdField))

--- a/src/VstsSyncMigrator.Core/Execution/MigrationContext/AttachementExportMigrationContext.cs
+++ b/src/VstsSyncMigrator.Core/Execution/MigrationContext/AttachementExportMigrationContext.cs
@@ -49,8 +49,9 @@ namespace VstsSyncMigrator.Engine
                 Trace.Write(string.Format("Attachement Export: {0} of {1} - {2}", current, sourceWIS.Count, wi.Id));
                 foreach (Attachment wia in wi.Attachments)
                 {
-                    string reflectedId = sourceStore.CreateReflectedWorkItemId(wi);
-                    string fname = string.Format("{0}#{1}", reflectedId.Replace("/", "--").Replace(":", "+"), wia.Name);
+                    string reflectedId = wi.Fields[me.ReflectedWorkItemIdFieldName].Value.ToString(); 
+                    reflectedId = int.Parse(reflectedId.Substring(reflectedId.LastIndexOf(@"/") + 1)).ToString();
+                    string fname = string.Format("{0}#{1}", reflectedId, wia.Name);
                     Trace.Write("-");
                     Trace.Write(fname);
                     string fpath = Path.Combine(exportPath, fname);

--- a/src/VstsSyncMigrator.Core/Execution/MigrationContext/AttachementImportMigrationContext.cs
+++ b/src/VstsSyncMigrator.Core/Execution/MigrationContext/AttachementImportMigrationContext.cs
@@ -47,11 +47,11 @@ namespace VstsSyncMigrator.Engine
                     if (fileNameParts.Length != 2)
                         continue;
 
-                    string reflectedID = fileNameParts[0].Replace('+', ':').Replace("--", "/");
+                    int reflectedID = int.Parse(fileNameParts[0]);
                     string targetFileName = fileNameParts[1];
                     var renamedFilePath = Path.Combine(Path.GetDirectoryName(file), targetFileName);
                     File.Move(file, renamedFilePath);
-                    targetWI = targetStore.FindReflectedWorkItemByReflectedWorkItemId(reflectedID, me.ReflectedWorkItemIdFieldName);
+                    targetWI = targetStore.Store.GetWorkItem(reflectedID);
                     if (targetWI != null)
                     {
                         Trace.WriteLine(string.Format("{0} of {1} - Import {2} to {3}", current, files.Count, fileName, targetWI.Id));


### PR DESCRIPTION
Hello @MrHinsh according your suggestion I have submitted  new Pull Request. 

My changes relate to the following files:

_**Program.cs**_ -  small changes set local time, start and end time, and last this is the name of the log file now is called as name of your json file.  In my case I have almost 15000 work items, so I used several configs with different query bit. This is helped me to reduce time of working tool, so I have run it in parallel mode. Works great :)
![2018-08-21 11_34_37-tfs to vsts teams - house of devops _ microsoft teams](https://user-images.githubusercontent.com/18549964/44390579-505eb080-a536-11e8-940b-3b798fe685c4.png)

_**EngineConfiguration.cs, FixGitCommitLinks.cs**_ - added ability to use QueryBit in the json configuration file for FixGitCommitLinksConfig
![code](https://user-images.githubusercontent.com/18549964/44389364-4d15f580-a533-11e8-8f3a-4a25dbf9c4f7.png)
Also added the ability to process ArtifactLinkType.Name = "Pull Request". 

**AttachementExportMigrationContext.cs, AttachementImportMigrationContext.cs** - little bit changed the approach of storing file name format [Issue # 139](https://github.com/nkdAgility/vsts-sync-migration/issues/139)

**WorkItemRevisionReplayMigrationContext.cs** - [Issue #150](https://github.com/nkdAgility/vsts-sync-migration/issues/150)

I am looking forward your comments and many thanks for your time.
